### PR TITLE
Add support for AWS Organizations and SNS encryption for multi-accounts

### DIFF
--- a/AccessKeyRotationChildAccounts.yaml
+++ b/AccessKeyRotationChildAccounts.yaml
@@ -14,6 +14,9 @@ Parameters:
   SNSTopic:
     Type: String
     Description: The SNS Topic to be used for sending notifications regarding noncompliant Access Keys
+  KMSKeyArn:
+    Type: String
+    Description: The KMS Key to be used for encrypting notifications
   MaximumExecutionFrequency:
     Type: String
     Default: TwentyFour_Hours
@@ -62,6 +65,15 @@ Resources:
               - Effect: Allow
                 Action: 'sns:Publish'
                 Resource: !Ref SNSTopic
+        - PolicyName: AccessKeyKmsKeyAccessPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 
+                  - 'kms:Decrypt'
+                  - 'kms:GenerateDataKey*'
+                Resource: !Ref KMSKeyArn
       RoleName: AccessKeyRotationRemediationRole
 
   AccessKeyRotationAutomationDoc:
@@ -156,6 +168,8 @@ Metadata:
           default: Required
         Parameters:
           - maxAccessKeyAge
+          - KMSKeyArn
+          - SNSTopic
       - Label:
           default: Optional
         Parameters: []    

--- a/AccessKeyRotationParentAccount.yaml
+++ b/AccessKeyRotationParentAccount.yaml
@@ -76,7 +76,7 @@ Resources:
               AWS: !If [OrgManaged, '*', !Ref TargetAccounts]
             Action:
               - 'kms:Decrypt'
-              - 'kms:GenerateDataKey'
+              - 'kms:GenerateDataKey*'
             Resource: '*'
             Condition:
               !If
@@ -84,10 +84,7 @@ Resources:
                 - 
                   StringEquals:
                     aws:PrincipalOrgID: !Ref OrganizationID
-                    kms:ViaService: "sns.amazonaws.com"
-                - 
-                  StringEquals:
-                    kms:ViaService: "sns.amazonaws.com"
+                - !Ref 'AWS::NoValue'
       KeySpec: SYMMETRIC_DEFAULT
       KeyUsage: ENCRYPT_DECRYPT      
 
@@ -101,3 +98,6 @@ Outputs:
   SNSTopicOutput:
     Description: The SNS Topic that was created
     Value: !Ref SNSTopic
+  KMSKeyOutput:
+    Description: The KMS key that was created
+    Value: !GetAtt KMSKey.Arn

--- a/AccessKeyRotationParentAccount.yaml
+++ b/AccessKeyRotationParentAccount.yaml
@@ -1,18 +1,31 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Create an SNS Topic to publish results for AWS Config Rule Access-Key-Rotation
 Parameters:
-  TargetAccounts:
+  MultiAccountMethod:
     Type: String
-    Description: The list of target AWS Account Ids, comma-separated
+    Description: Use AWS Organizations for child accounts or provide an account list?
+    AllowedValues:
+      - "AWS Organizations"
+      - "Account List"
+  OrganizationID:
+    Type: String
+    Description: The AWS Organization ID to allow 
+  TargetAccounts:
+    Type: CommaDelimitedList
+    Description: The list of target AWS Account IDs, comma-separated
+
+Conditions:
+  OrgManaged: !Equals [!Ref MultiAccountMethod, 'AWS Organizations']
+
 Resources:
   SNSTopic:
     Type: 'AWS::SNS::Topic'
     Properties:
       DisplayName: >-
-        SNS topic to distribute information regarding access key rotation rule
-        non-compliance
+        Access Key rotation rule non-compliance
       TopicName: AccessKeyRotationTopic
-      KmsMasterKeyId: alias/aws/sns
+      KmsMasterKeyId: !Ref KMSKey
+
   SNSTopicPolicy:
     Type: AWS::SNS::TopicPolicy
     Properties:
@@ -31,12 +44,59 @@ Resources:
               - !Ref 'AWS::AccountId'
               - ':AccessKeyRotationTopic'          
           Principal:
-            AWS: 
-              !Split 
-                - ","
-                - !Ref TargetAccounts
+            AWS: !If [OrgManaged, '*', !Ref TargetAccounts]
+          Condition:
+            !If
+              - OrgManaged
+              - 
+                StringEquals:
+                  aws:PrincipalOrgID: !Ref OrganizationID
+              - !Ref "AWS::NoValue"
       Topics:
       - !Ref SNSTopic
+
+  KMSKey:
+    Type: 'AWS::KMS::Key'
+    Properties: 
+      Description: Key for Access Key Rotation SNS Topic
+      EnableKeyRotation: true
+      KeyPolicy: 
+        Version: 2012-10-17
+        Id: key-default-1
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Join ['', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':root'] ]
+            Action: 'kms:*'
+            Resource: '*'
+          - Sid: Allow use of the key
+            Effect: Allow
+            Principal:
+              AWS: !If [OrgManaged, '*', !Ref TargetAccounts]
+            Action:
+              - 'kms:Decrypt'
+              - 'kms:GenerateDataKey'
+            Resource: '*'
+            Condition:
+              !If
+                - OrgManaged
+                - 
+                  StringEquals:
+                    aws:PrincipalOrgID: !Ref OrganizationID
+                    kms:ViaService: "sns.amazonaws.com"
+                - 
+                  StringEquals:
+                    kms:ViaService: "sns.amazonaws.com"
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyUsage: ENCRYPT_DECRYPT      
+
+  KMSKeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties: 
+      AliasName: alias/accessKeys/sns
+      TargetKeyId: !Ref KMSKey
+
 Outputs:
   SNSTopicOutput:
     Description: The SNS Topic that was created


### PR DESCRIPTION
This update provides support for using either the original multi-account comma-delimited list *or* enabling support for AWS Organizations for all existing and future accounts. SNS Topic encryption is enabled across accounts through use of a KMS customer managed key (CMK).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
